### PR TITLE
Remove dependency 'jshint' from run dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "argsarray": "0.0.1",
     "inherits": "~2.0.1",
-    "jshint": "^2.7.0",
     "lie": "^2.6.0",
     "pouchdb": "pouchdb/pouchdb",
     "pouchdb-extend": "^0.1.2",


### PR DESCRIPTION
`npm WARN package.json Dependency 'jshint' exists in both dependencies and devDependencies, using 'jshint@^2.7.0' from dependencies`